### PR TITLE
Move hyp/ref path to `get_scores` instead of init in FilesRouge

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ Given two files `hyp_path`, `ref_path`, with the same number (`n`) of lines, cal
 ```python
 from rouge import FilesRouge
 
-files_rouge = FilesRouge(hyp_path, ref_path)
-scores = files_rouge.get_scores()
+files_rouge = FilesRouge()
+scores = files_rouge.get_scores(hyp_path, ref_path)
 # or
-scores = files_rouge.get_scores(avg=True)
+scores = files_rouge.get_scores(hyp_path, ref_path, avg=True)
 ```

--- a/bin/rouge_cmd.py
+++ b/bin/rouge_cmd.py
@@ -39,9 +39,9 @@ def main():
         assert(os.path.isfile(hyp))
         assert(os.path.isfile(ref))
 
-        files_rouge = FilesRouge(hyp, ref, metrics, stats)
-        scores = files_rouge.get_scores(avg=args.avg,
-                                        ignore_empty=args.ignore_empty)
+        files_rouge = FilesRouge(metrics, stats)
+        scores = files_rouge.get_scores(
+            hyp, ref,avg=args.avg, ignore_empty=args.ignore_empty)
 
         print(json.dumps(scores, indent=2))
     else:

--- a/rouge/rouge.py
+++ b/rouge/rouge.py
@@ -7,12 +7,12 @@ import os
 
 
 class FilesRouge:
-    def __init__(self, hyp_path, ref_path, metrics=None, stats=None,
-                 batch_lines=None):
+    def __init__(self, metrics=None, stats=None):
+        self.rouge = Rouge(metrics=metrics, stats=stats)
+
+    def _check_files(self, hyp_path, ref_path):
         assert(os.path.isfile(hyp_path))
         assert(os.path.isfile(ref_path))
-
-        self.rouge = Rouge(metrics=metrics, stats=stats)
 
         def line_count(path):
             count = 0
@@ -25,13 +25,7 @@ class FilesRouge:
         ref_lc = line_count(ref_path)
         assert(hyp_lc == ref_lc)
 
-        assert(batch_lines is None or type(batch_lines) == int)
-
-        self.hyp_path = hyp_path
-        self.ref_path = ref_path
-        self.batch_lines = batch_lines
-
-    def get_scores(self, avg=False, ignore_empty=False):
+    def get_scores(self, hyp_path, ref_path, avg=False, ignore_empty=False):
         """Calculate ROUGE scores between each pair of
         lines (hyp_file[i], ref_file[i]).
         Args:
@@ -39,10 +33,11 @@ class FilesRouge:
           * ref_path: references file path
           * avg (False): whether to get an average scores or a list
         """
-        hyp_path, ref_path = self.hyp_path, self.ref_path
+        self._check_files(hyp_path, ref_path)
 
         with io.open(hyp_path, encoding="utf-8", mode="r") as hyp_file:
             hyps = [line[:-1] for line in hyp_file]
+
         with io.open(ref_path, encoding="utf-8", mode="r") as ref_file:
             refs = [line[:-1] for line in ref_file]
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -14,7 +14,7 @@ class BasicTest(TestCase):
             self.data = json.load(f)
 
         self.rouge = rouge.Rouge()
-        self.files_rouge = rouge.FilesRouge(self.hyp_path, self.ref_path)
+        self.files_rouge = rouge.FilesRouge()
 
     def test_one_sentence(self):
         for d in self.data[:1]:
@@ -34,5 +34,5 @@ class BasicTest(TestCase):
         data = self.data
         hyps, refs = map(list, zip(*[[d['hyp'], d['ref']] for d in data]))
         expected_scores = [d['scores'] for d in data]
-        scores = self.files_rouge.get_scores()
+        scores = self.files_rouge.get_scores(self.hyp_path, self.ref_path)
         self.assertEqual(expected_scores, scores)


### PR DESCRIPTION
It does not really make sense to me to set the path as parameter.

E.g. not really practical if one wants to iterate over list of files, i.e. I would prefer something like
```
for hyp_path, ref_path in zip(paths):
    scores = files_rouge.get_scores(hyp_path, ref_path)
```