### PR TITLE
Fix scores (do not remove duplicate + fix beta for ROUGE-L(F))

### DIFF
--- a/bin/rouge_cmd.py
+++ b/bin/rouge_cmd.py
@@ -46,8 +46,8 @@ def main():
         print(json.dumps(scores, indent=2))
     else:
         hyp, ref = args.hypothesis, args.reference
-        assert(type(hyp) == str)
-        assert(type(ref) == str)
+        assert(isinstance(hyp, str))
+        assert(isinstance(ref, str))
 
         rouge = Rouge(metrics, stats)
         scores = rouge.get_scores(hyp, ref, avg=args.avg)

--- a/rouge/rouge_score.py
+++ b/rouge/rouge_score.py
@@ -344,7 +344,7 @@ def rouge_l_summary_level(
     Calculated according to:
     R_lcs = SUM(1, u)[LCS<union>(r_i,C)]/m
     P_lcs = SUM(1, u)[LCS<union>(r_i,C)]/n
-    F_lcs = ((1 + beta^2)*R_lcs*P_lcs) / (R_lcs + (beta^2) * P_lcs)
+    F_lcs = (2*R_lcs*P_lcs) / (R_lcs * P_lcs)
 
     where:
     SUM(i,u) = SUM from i through u
@@ -392,10 +392,8 @@ def rouge_l_summary_level(
     llcs = union_lcs_sum_across_all_references
     r_lcs = llcs / m
     p_lcs = llcs / n
-    beta = p_lcs / (r_lcs + 1e-12)
-    num = (1 + (beta**2)) * r_lcs * p_lcs
-    denom = r_lcs + ((beta**2) * p_lcs)
-    f_lcs = num / (denom + 1e-12)
+
+    f_lcs = 2.0 * ((p_lcs * r_lcs) / (p_lcs + r_lcs + 1e-8))
 
     if raw_results:
         o = {


### PR DESCRIPTION
Multiple fixes that has impact on the scores (getting in line with official `ROUGE-1.5.5` package.


1. Fix the ROUGE calculation to use `list` of n-grams instead of `set` (which remove duplicates). I experimented against the original ROUGE-1.5.5 package using [`files2rouge`](https://github.com/pltrdy/files2rouge) (more details below)
2. Fix ROUGE-L(F) which was using a `beta` value different from the official package.
3. Introduce a `raw_results` option in order to get not aggregated counts (i.e. before calculating recall, precision, and f1 score), for example to run micro-averaging (instead of macro).


----
#### Evaluation
**dummy hyp file:**
```
01 02 03 04 05 01 02 03 04 06 07 08 09 10 11 12 01 02 03
05 04 03 06
```
**dummy reference file:**
```
01 92 93 94 05 91 92 03 94 06 97 98 09 10 91 12 91 02 03 98 96 97
05 94 03 06 98 97
```
**Official evaluation (using files2rouge, based on ROUGE-1.5.5):**
```
files2rouge hyp.0.txt ref.0.txt 
Preparing documents... 0 line(s) ignored
Running ROUGE...
---------------------------------------------
1 ROUGE-1 Average_R: 0.45454 (95%-conf.int. 0.40909 - 0.50000)
1 ROUGE-1 Average_P: 0.61184 (95%-conf.int. 0.47368 - 0.75000)
1 ROUGE-1 Average_F: 0.51951 (95%-conf.int. 0.43902 - 0.60000)
---------------------------------------------
1 ROUGE-2 Average_R: 0.14762 (95%-conf.int. 0.09524 - 0.20000)
1 ROUGE-2 Average_P: 0.22222 (95%-conf.int. 0.11111 - 0.33333)
1 ROUGE-2 Average_F: 0.17628 (95%-conf.int. 0.10256 - 0.25000)
---------------------------------------------
1 ROUGE-L Average_R: 0.45454 (95%-conf.int. 0.40909 - 0.50000)
1 ROUGE-L Average_P: 0.61184 (95%-conf.int. 0.47368 - 0.75000)
1 ROUGE-L Average_F: 0.51951 (95%-conf.int. 0.43902 - 0.60000)
```
**`pltrdy/rouge` evaluation:**
```
rouge -f --avg  hyp.0.txt ref.0.txt 
{
  "rouge-1": {
    "f": 0.5195121902353361,
    "p": 0.6118421052631579,
    "r": 0.4545454545454546
  },
  "rouge-2": {
    "f": 0.17628204645309434,
    "p": 0.2222222222222222,
    "r": 0.14761904761904762
  },
  "rouge-l": {
    "f": 0.5195121902353361,
    "p": 0.6118421052631579,
    "r": 0.4545454545454546
  }
}
```